### PR TITLE
Removed CleanUp

### DIFF
--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -36,22 +36,6 @@ namespace Tests.TwoDimension
 		}
 
 		[Test]
-		public void AreaCleanUp()
-		{
-			Area area = new Area();
-			var mockTile = new Mock<ITile>();
-
-			// Add entity to Tile
-			area.Add(mockTile.Object);
-
-			// Clean Up
-			area.CleanUp();
-
-			// Make sure the entity clean up was called
-			mockTile.Verify(tile => tile.CleanUp(), Times.Exactly(1));
-		}
-
-		[Test]
 		public void AreaDestroy()
 		{
 			Area area = new Area();
@@ -68,6 +52,22 @@ namespace Tests.TwoDimension
 
 			// Destroy event was fired
 			Assert.IsTrue(destroyedCalled);
+		}
+
+		[Test]
+		public void AreaDestroyPropagation()
+		{
+			Area area = new Area();
+			var mockTile = new Mock<ITile>();
+
+			// Add entity to Tile
+			area.Add(mockTile.Object);
+
+			// Destroy with propagation
+			area.Destroy(true);
+
+			// Make sure the tile below also received the destroy
+			mockTile.Verify(tile => tile.Destroy(true), Times.Exactly(1));
 		}
 
 		[Test]

--- a/Tests/TwoDimension/EntityTests.cs
+++ b/Tests/TwoDimension/EntityTests.cs
@@ -35,22 +35,6 @@ namespace Tests.TwoDimension
 		}
 
 		[Test]
-		public void EntityCleanUp()
-		{
-			Entity entity = new Entity();
-			var mockTile = new Mock<ITile>();
-
-			// Set Tile Parent
-			entity.SetParent(mockTile.Object);
-
-			// Clean Up
-			entity.CleanUp();
-
-			// Make sure the tile remove was called with the entity
-			mockTile.Verify(tile => tile.Remove(entity), Times.Exactly(1));
-		}
-
-		[Test]
 		public void EntityDestroy()
 		{
 			Entity entity = new Entity();
@@ -67,6 +51,22 @@ namespace Tests.TwoDimension
 
 			// Destroy event was fired
 			Assert.IsTrue(destroyedCalled);
+		}
+
+		[Test]
+		public void EntityDestroyTileRemove()
+		{
+			Entity entity = new Entity();
+			var mockTile = new Mock<ITile>();
+
+			// Set Tile Parent
+			entity.SetParent(mockTile.Object);
+
+			// Destroy
+			entity.Destroy();
+
+			// Make sure the tile remove was called with the entity
+			mockTile.Verify(tile => tile.Remove(entity), Times.Exactly(1));
 		}
 
 		[Test]

--- a/Tests/TwoDimension/TileTests.cs
+++ b/Tests/TwoDimension/TileTests.cs
@@ -37,7 +37,7 @@ namespace Tests.TwoDimension
 		}
 
 		[Test]
-		public void TileCleanUp()
+		public void TileDestroyPropagation()
 		{
 			Tile tile = new Tile();
 			var mockEntity = new Mock<IEntity>();
@@ -46,10 +46,10 @@ namespace Tests.TwoDimension
 			tile.Add(mockEntity.Object);
 
 			// Clean Up
-			tile.CleanUp();
+			tile.Destroy(true);
 
-			// Make sure the entity clean up was called
-			mockEntity.Verify(entity => entity.CleanUp(), Times.Exactly(1));
+			// Make sure the entity was also called to be destroyed
+			mockEntity.Verify(entity => entity.Destroy(), Times.Exactly(1));
 		}
 
 		[Test]

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -143,24 +143,18 @@ namespace TileSystem.Implementation.TwoDimension
 		}
 
 		/// <summary>
-		/// Clean up all the tiles and call the destroy events
-		/// </summary>
-		public virtual void CleanUp()
-		{
-			for (int i = tiles.Count - 1; i >= 0; i--)
-			{
-				tiles[i].CleanUp();
-			}
-
-			// TODO: Is this necessary here?
-			Destroy();
-		}
-
-		/// <summary>
 		/// Destroy this area and emit the event
 		/// </summary>
-		public virtual void Destroy()
+		public virtual void Destroy(bool propagate = false)
 		{
+			if (propagate)
+			{
+				for (int i = tiles.Count - 1; i >= 0; i--)
+				{
+					tiles[i].Destroy(propagate);
+				}
+			}
+
 			if (Destroyed != null)
 			{
 				Destroyed.Invoke(this, new AreaDestroyedArgs());

--- a/TileSystem/Implementation/TwoDimension/Entity.cs
+++ b/TileSystem/Implementation/TwoDimension/Entity.cs
@@ -56,24 +56,15 @@ namespace TileSystem.Implementation.TwoDimension
 		}
 
 		/// <summary>
-		/// Clean up from containing Tile and call the destroy events
+		/// Destroy this entity and emit the event
 		/// </summary>
-		public virtual void CleanUp()
+		public virtual void Destroy()
 		{
 			if (Tile != null)
 			{
 				Tile.Remove(this);
 			}
 
-			// TODO: Is this necessary here?
-			Destroy();
-		}
-
-		/// <summary>
-		/// Destroy this entity and emit the event
-		/// </summary>
-		public virtual void Destroy()
-		{
 			if (Destroyed != null)
 			{
 				Destroyed.Invoke(this, new EntityDestroyedArgs(this));

--- a/TileSystem/Implementation/TwoDimension/Tile.cs
+++ b/TileSystem/Implementation/TwoDimension/Tile.cs
@@ -121,24 +121,18 @@ namespace TileSystem.Implementation.TwoDimension
 		}
 
 		/// <summary>
-		/// Clean up all the entities and call the destroy events
-		/// </summary>
-		public virtual void CleanUp()
-		{
-			for (int i = entities.Count - 1; i >= 0; i--)
-			{
-				entities[i].CleanUp();
-			}
-
-			// TODO: Is this necessary here?
-			Destroy();
-		}
-
-		/// <summary>
 		/// Destroy this tile and emit the event
 		/// </summary>
-		public virtual void Destroy()
+		public virtual void Destroy(bool propagate = false)
 		{
+			if (propagate)
+			{
+				for (int i = entities.Count - 1; i >= 0; i--)
+				{
+					entities[i].Destroy();
+				}
+			}
+
 			if (Destroyed != null)
 			{
 				Destroyed.Invoke(this, new TileDestroyedArgs());

--- a/TileSystem/Interfaces/Base/IArea.cs
+++ b/TileSystem/Interfaces/Base/IArea.cs
@@ -32,7 +32,6 @@ namespace TileSystem.Interfaces.Base
 		ILevel Level { get; }
 
 		event EventHandler<AreaDestroyedArgs> Destroyed;
-		void Destroy();
-		void CleanUp();
+		void Destroy(bool propagate = false);
 	}
 }

--- a/TileSystem/Interfaces/Base/IEntity.cs
+++ b/TileSystem/Interfaces/Base/IEntity.cs
@@ -22,6 +22,5 @@ namespace TileSystem.Interfaces.Base
 
 		event EventHandler<EntityDestroyedArgs> Destroyed;
 		void Destroy();
-		void CleanUp();
 	}
 }

--- a/TileSystem/Interfaces/Base/ITile.cs
+++ b/TileSystem/Interfaces/Base/ITile.cs
@@ -26,7 +26,6 @@ namespace TileSystem.Interfaces.Base
 		IArea Area { get; }
 
 		event EventHandler<TileDestroyedArgs> Destroyed;
-		void Destroy();
-		void CleanUp();
+		void Destroy(bool propagate = false);
 	}
 }


### PR DESCRIPTION
# Description

CleanUp functions were removed and replaced with a bool in the destroy event to decide whether to destroy all the children of the object.
# Why

There was confusion between the use of the cleanup which is used when we are moving scene and want to destroy everything in the chain, and the destroy event which is to tell the UI and the system the object has been destroyed.
# What Changed
- Removed Cleanup
- Updated Interefaces to update the destroy call
- Tests
