### PR TITLE
Level code and updated interfaces to accomodate

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -61,7 +61,10 @@
     <Compile Include="Management\TileChangeManagerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TwoDimension\AreaTests.cs" />
+    <Compile Include="TwoDimension\CreationTests.cs" />
     <Compile Include="TwoDimension\EntityTests.cs" />
+    <Compile Include="TwoDimension\LevelTests.cs" />
+    <Compile Include="TwoDimension\PositionTests.cs" />
     <Compile Include="TwoDimension\TileTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -156,6 +156,8 @@ namespace Tests.TwoDimension
 			Assert.That(() => area.SetPosition(null, mockPosition.Object), Throws.ArgumentNullException);
 			Assert.That(() => area.SetPosition(mockLevel.Object, null), Throws.ArgumentNullException);
 
+			// TODO: Issue 13 (https://github.com/Wizcorp/TileSystem/issues/13)
+
 			// Test Set Position Works
 			Assert.That(() => area.SetPosition(mockLevel.Object, mockPosition.Object), Throws.Nothing);
 

--- a/Tests/TwoDimension/CreationTests.cs
+++ b/Tests/TwoDimension/CreationTests.cs
@@ -1,0 +1,138 @@
+﻿using Moq;
+
+using NUnit.Framework;
+
+using TileSystem.Interfaces.Base;
+using TileSystem.Interfaces.TwoDimension;
+using TileSystem.Implementation.TwoDimension;
+using TileSystem.Interfaces.Creation;
+
+namespace Tests.TwoDimension
+{
+	[TestFixture]
+	[Category("TwoDimension")]
+	public class CreationTests
+	{
+		[Test]
+		public void CreateArea()
+		{
+			// Create mock factories
+			var mockAreaFactory = new Mock<IAreaFactory>();
+			var mockTileFactory = new Mock<ITileFactory>();
+			var mockEntityFactory = new Mock<IEntityFactory>();
+
+			// Create a mock position that will be used with the area set position
+			var mockPosition2D = new Mock<IPosition2D>();
+
+			// Set up area factory so it will have a mock area to invoke without throwing in the create area
+			mockAreaFactory.Setup(factory => factory.CreateArea(null, null)).Returns(new Mock<IArea>().Object);
+
+			// Create level with mock factories
+			Level level = new Level(mockAreaFactory.Object, mockTileFactory.Object, mockEntityFactory.Object);
+
+			bool createdCalled = false;
+
+			// Register added event and make sure it is called
+			level.AreaCreated += (sender, args) =>
+			{
+				createdCalled = true;
+			};
+
+			// Test Null
+			Assert.That(() => level.CreateArea(null, mockPosition2D.Object, null, null), Throws.ArgumentNullException);
+
+			// Test Null
+			Assert.That(() => level.CreateArea(level, null, null, null), Throws.ArgumentNullException);
+
+			// Assert add event was not called
+			Assert.IsFalse(createdCalled);
+
+			// Test Create Works
+			Assert.That(() => level.CreateArea(level, mockPosition2D.Object, null, null), Throws.Nothing);
+
+			// Assert add event was called
+			Assert.IsTrue(createdCalled);
+		}
+
+		[Test]
+		public void CreateTile()
+		{
+			// Create mock factories
+			var mockAreaFactory = new Mock<IAreaFactory>();
+			var mockTileFactory = new Mock<ITileFactory>();
+			var mockEntityFactory = new Mock<IEntityFactory>();
+
+			// Create a mock position that will be used with the tile set position
+			var mockPosition2D = new Mock<IPosition2D>();
+			// Create a mock area that will be used with tile set position
+			var mockArea = new Mock<IArea>();
+
+			// Set up tile factory so it will have a mock tile to invoke without throwing in the create tile
+			mockTileFactory.Setup(factory => factory.CreateTile(null, null)).Returns(new Mock<ITile>().Object);
+
+			// Create level with mock factories
+			Level level = new Level(mockAreaFactory.Object, mockTileFactory.Object, mockEntityFactory.Object);
+
+			bool createdCalled = false;
+
+			// Register added event and make sure it is called
+			level.TileCreated += (sender, args) =>
+			{
+				createdCalled = true;
+			};
+
+			// Test Null
+			Assert.That(() => level.CreateTile(null, mockPosition2D.Object, null, null), Throws.ArgumentNullException);
+
+			// Test Null
+			Assert.That(() => level.CreateTile(mockArea.Object, null, null, null), Throws.ArgumentNullException);
+
+			// Assert add event was not called
+			Assert.IsFalse(createdCalled);
+
+			// Test Create Works
+			Assert.That(() => level.CreateTile(mockArea.Object, mockPosition2D.Object, null, null), Throws.Nothing);
+
+			// Assert add event was called
+			Assert.IsTrue(createdCalled);
+		}
+
+		[Test]
+		public void CreateEntity()
+		{
+			// Create mock factories
+			var mockAreaFactory = new Mock<IAreaFactory>();
+			var mockTileFactory = new Mock<ITileFactory>();
+			var mockEntityFactory = new Mock<IEntityFactory>();
+
+			// Create a mock tile that will be used with entity set parent
+			var mockTile = new Mock<ITile>();
+
+			// Set up entity factory so it will have a mock entity to invoke without throwing in the create entity
+			mockEntityFactory.Setup(factory => factory.CreateEntity(null, null)).Returns(new Mock<IEntity>().Object);
+
+			// Create level with mock factories
+			Level level = new Level(mockAreaFactory.Object, mockTileFactory.Object, mockEntityFactory.Object);
+
+			bool createdCalled = false;
+
+			// Register added event and make sure it is called
+			level.EntityCreated += (sender, args) =>
+			{
+				createdCalled = true;
+			};
+
+			// Test Null
+			Assert.That(() => level.CreateEntity(null, null, null), Throws.ArgumentNullException);
+
+			// Assert add event was not called
+			Assert.IsFalse(createdCalled);
+
+			// Test Create Works
+			Assert.That(() => level.CreateEntity(mockTile.Object, null, null), Throws.Nothing);
+
+			// Assert add event was called
+			Assert.IsTrue(createdCalled);
+		}
+	}
+}

--- a/Tests/TwoDimension/EntityTests.cs
+++ b/Tests/TwoDimension/EntityTests.cs
@@ -60,7 +60,7 @@ namespace Tests.TwoDimension
 			var mockTile = new Mock<ITile>();
 
 			// Set Tile Parent
-			entity.SetParent(mockTile.Object);
+			entity.SetTile(mockTile.Object);
 
 			// Destroy
 			entity.Destroy();
@@ -70,15 +70,15 @@ namespace Tests.TwoDimension
 		}
 
 		[Test]
-		public void SetParent()
+		public void SetTile()
 		{
 			Entity entity = new Entity();
 			var mockTile = new Mock<ITile>();
 
 			// Test Null
-			Assert.That(() => entity.SetParent(null), Throws.ArgumentNullException);
+			Assert.That(() => entity.SetTile(null), Throws.ArgumentNullException);
 			// Test Set Parent Works
-			Assert.That(() => entity.SetParent(mockTile.Object), Throws.Nothing);
+			Assert.That(() => entity.SetTile(mockTile.Object), Throws.Nothing);
 
 			Assert.AreSame(entity.Tile, mockTile.Object);
 		}

--- a/Tests/TwoDimension/LevelTests.cs
+++ b/Tests/TwoDimension/LevelTests.cs
@@ -112,14 +112,14 @@ namespace Tests.TwoDimension
 		[Test]
 		public void PositionGet()
 		{
-			// TODO: Add issue
+			// TODO: Issue 15 (https://github.com/Wizcorp/TileSystem/issues/15)
 			Assert.Fail();
 		}
 
 		[Test]
 		public void PositionGetNeighbours()
 		{
-			// TODO: Add issue
+			// TODO: Issue 15 (https://github.com/Wizcorp/TileSystem/issues/15)
 			Assert.Fail();
 		}
 	}

--- a/Tests/TwoDimension/LevelTests.cs
+++ b/Tests/TwoDimension/LevelTests.cs
@@ -1,0 +1,126 @@
+﻿using Moq;
+
+using NUnit.Framework;
+
+using TileSystem.Interfaces.Base;
+using TileSystem.Interfaces.TwoDimension;
+using TileSystem.Implementation.TwoDimension;
+using TileSystem.Interfaces.Creation;
+
+namespace Tests.TwoDimension
+{
+	[TestFixture]
+	[Category("TwoDimension")]
+	public class LevelTests
+	{
+		[Test]
+		public void LevelFactoryConstructor()
+		{
+			// Create mock factories
+			var mockAreaFactory = new Mock<IAreaFactory>();
+			var mockTileFactory = new Mock<ITileFactory>();
+			var mockEntityFactory = new Mock<IEntityFactory>();
+
+			// Test Area Null
+			Assert.That(() => new Level(null, mockTileFactory.Object, mockEntityFactory.Object), Throws.ArgumentNullException);
+
+			// Test Tile Null
+			Assert.That(() => new Level(mockAreaFactory.Object, null, mockEntityFactory.Object), Throws.ArgumentNullException);
+
+			// Test Entity Null
+			Assert.That(() => new Level(mockAreaFactory.Object, mockTileFactory.Object, null), Throws.ArgumentNullException);
+
+			// Test Create Works
+			Assert.That(() => new Level(mockAreaFactory.Object, mockTileFactory.Object, mockEntityFactory.Object), Throws.Nothing);
+		}
+
+		[Test]
+		public void AreaAdd()
+		{
+			Level level = new Level();
+			var mockArea = new Mock<IArea>();
+
+			bool addCalled = false;
+
+			// Register added event and make sure it is called
+			level.AreaAdded += (sender, args) =>
+			{
+				addCalled = true;
+			};
+
+			// Test Null
+			Assert.That(() => level.Add(null), Throws.ArgumentNullException);
+
+			// Assert add event was not called
+			Assert.IsFalse(addCalled);
+
+			// Test Add Works
+			Assert.That(() => level.Add(mockArea.Object), Throws.Nothing);
+
+			// Assert add event was called
+			Assert.IsTrue(addCalled);
+
+			// Reset before next test
+			addCalled = false;
+
+			// Test duplicate fails
+			Assert.That(() => level.Add(mockArea.Object), Throws.ArgumentException);
+
+			// Assert add event was not called
+			Assert.IsFalse(addCalled);
+		}
+
+		[Test]
+		public void AreaRemove()
+		{
+			Level level = new Level();
+			var mockArea = new Mock<IArea>();
+
+			bool removeCalled = false;
+
+			// Register removed event and make sure it is called
+			level.AreaRemoved += (sender, args) =>
+			{
+				removeCalled = true;
+			};
+
+			// Add Area
+			level.Add(mockArea.Object);
+
+			// Test Null
+			Assert.That(() => level.Remove(null), Throws.ArgumentNullException);
+
+			// Assert remove event was not called
+			Assert.IsFalse(removeCalled);
+
+			// Test Remove (true removing the object)
+			Assert.That(level.Remove(mockArea.Object), Is.True);
+
+			// Assert remove event was called
+			Assert.IsTrue(removeCalled);
+
+			// Reset before next test
+			removeCalled = false;
+
+			// Test Remove (false not removing the object)
+			Assert.That(level.Remove(mockArea.Object), Is.False);
+
+			// Assert remove event was not called
+			Assert.IsFalse(removeCalled);
+		}
+
+		[Test]
+		public void PositionGet()
+		{
+			// TODO: Add issue
+			Assert.Fail();
+		}
+
+		[Test]
+		public void PositionGetNeighbours()
+		{
+			// TODO: Add issue
+			Assert.Fail();
+		}
+	}
+}

--- a/Tests/TwoDimension/PositionTests.cs
+++ b/Tests/TwoDimension/PositionTests.cs
@@ -1,8 +1,5 @@
-﻿using Moq;
+﻿using NUnit.Framework;
 
-using NUnit.Framework;
-
-using TileSystem.Interfaces.Base;
 using TileSystem.Interfaces.TwoDimension;
 using TileSystem.Implementation.TwoDimension;
 

--- a/Tests/TwoDimension/PositionTests.cs
+++ b/Tests/TwoDimension/PositionTests.cs
@@ -1,0 +1,37 @@
+﻿using Moq;
+
+using NUnit.Framework;
+
+using TileSystem.Interfaces.Base;
+using TileSystem.Interfaces.TwoDimension;
+using TileSystem.Implementation.TwoDimension;
+
+namespace Tests.TwoDimension
+{
+	[TestFixture]
+	[Category("TwoDimension")]
+	public class PositionTests
+	{
+		[Test]
+		public void PositionConstructor()
+		{
+			int x = 0;
+			int y = 0;
+
+			// Test Area Null
+			Assert.That(() => new Position2D(x, y), Throws.Nothing);
+
+			// Create position and check x,y
+			IPosition2D pos = new Position2D(x, y);
+			Assert.AreEqual(x, pos.X);
+			Assert.AreEqual(y, pos.Y);
+		}
+
+		[Test]
+		public void CompareTo()
+		{
+			// TODO: Issue 11 (https://github.com/Wizcorp/TileSystem/issues/11)
+			Assert.Fail();
+		}
+	}
+}

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -26,8 +26,8 @@ namespace TileSystem.Implementation.TwoDimension
 		public event EventHandler<TileRemovedArgs> TileRemoved;
 
 		// Representation in the system
-		public string Type { get; private set; }
-		public string Variation { get; private set; }
+		public string Type { get; protected set; }
+		public string Variation { get; protected set; }
 
 		// Location in the system
 		public ILevel Level { get; private set; }

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -16,6 +16,10 @@ namespace TileSystem.Implementation.TwoDimension
 	/// </summary>
 	public class Area : IArea
 	{
+		// Position in 2d
+		private IPosition2D position2d;
+
+		// List of tiles this area contains
 		private List<ITile> tiles;
 
 		// Destroyed event from IArea
@@ -31,7 +35,10 @@ namespace TileSystem.Implementation.TwoDimension
 
 		// Location in the system
 		public ILevel Level { get; private set; }
-		public IPosition2D Position { get; private set; }
+		public IPosition Position
+		{
+			get { return position2d; }
+		}
 
 		/// <summary>
 		/// Default constructor sets up a list of ITile
@@ -58,7 +65,7 @@ namespace TileSystem.Implementation.TwoDimension
 		/// </summary>
 		/// <param name="level">Parent level</param>
 		/// <param name="position">position in 2d</param>
-		public void SetPosition(ILevel level, IPosition2D position)
+		public void SetPosition(ILevel level, IPosition position)
 		{
 			if (level == null)
 			{
@@ -70,8 +77,15 @@ namespace TileSystem.Implementation.TwoDimension
 				throw new ArgumentNullException("position", "Position can not be null");
 			}
 
+			IPosition2D pos = position as IPosition2D;
+
+			if (pos == null)
+			{
+				throw new ArgumentException("position must be of type IPosition2D", "position");
+			}
+
 			Level = level;
-			Position = position;
+			position2d = pos;
 		}
 
 		/// <summary>
@@ -155,6 +169,11 @@ namespace TileSystem.Implementation.TwoDimension
 				}
 			}
 
+			if (Level != null)
+			{
+				Level.Remove(this);
+			}
+
 			if (Destroyed != null)
 			{
 				Destroyed.Invoke(this, new AreaDestroyedArgs());
@@ -167,7 +186,7 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Formatted string representation of the Area(X,Y, Tile Count)</returns>
 		public override string ToString()
 		{
-			return string.Format("[Area X:{0} Y:{1}, Tiles Count:{2}]", Position.X, Position.Y, tiles.Count);
+			return string.Format("[Area X:{0} Y:{1}, Tiles Count:{2}]", position2d.X, position2d.Y, tiles.Count);
 		}
 	}
 }

--- a/TileSystem/Implementation/TwoDimension/Entity.cs
+++ b/TileSystem/Implementation/TwoDimension/Entity.cs
@@ -45,7 +45,7 @@ namespace TileSystem.Implementation.TwoDimension
 		/// Set the parent tile for this entity
 		/// </summary>
 		/// <param name="tile">Parent Tile</param>
-		public void SetParent(ITile tile)
+		public void SetTile(ITile tile)
 		{
 			if (tile == null)
 			{

--- a/TileSystem/Implementation/TwoDimension/Level.cs
+++ b/TileSystem/Implementation/TwoDimension/Level.cs
@@ -2,33 +2,149 @@
 using System.Collections.Generic;
 
 using TileSystem.Interfaces.Base;
+using TileSystem.Interfaces.Creation;
 using TileSystem.Interfaces.Management;
 
 namespace TileSystem.Implementation.TwoDimension
 {
-	public class Level : ILevel
+	/// <summary>
+	/// Level is the main container for our 2d space, it allows
+	/// for addition of areas and controls the creation of
+	/// areas, tiles and entities.
+	/// 
+	/// Notes:
+	/// We provide a 2d implementation in this format but this does
+	/// not have to be used in the same way, all the ICreateX interfaces
+	/// are designed to be placed anywhere in the structure, however the
+	/// ILevel, IArea, ITile, IEntity hierarchy is fixed.
+	/// </summary>
+	public class Level : ILevel, ICreateAreas, ICreateTiles, ICreateEntities
 	{
+		// List of areas in the system
+		private List<IArea> areas;
+
+		// Area Events
 		public event EventHandler<AreaAddedArgs> AreaAdded;
 		public event EventHandler<AreaRemovedArgs> AreaRemoved;
 
+		// Creation Events
+		public event EventHandler<AreaCreatedArgs> AreaCreated;
+		public event EventHandler<TileCreatedArgs> TileCreated;
+		public event EventHandler<EntityCreatedArgs> EntityCreated;
+
+		// Factories
+		public IAreaFactory AreaFactory { get; protected set; }
+		public ITileFactory TileFactory { get; protected set; }
+		public IEntityFactory EntityFactory { get; protected set; }
+
+		/// <summary>
+		/// Default constructor sets up a list of IAreas
+		/// </summary>
+		public Level()
+		{
+			areas = new List<IArea>();
+		}
+
+		/// <summary>
+		/// Constructor to allow inject of factories that are used
+		/// with the creation of Areas, Tiles, and Entities
+		/// </summary>
+		/// <param name="areaFactory">Area factory instance</param>
+		/// <param name="tileFactory">Tile factory instance</param>
+		/// <param name="entityFactory">Entity factory instance</param>
+		public Level(IAreaFactory areaFactory, ITileFactory tileFactory, IEntityFactory entityFactory) : this()
+		{
+			AreaFactory = areaFactory;
+			TileFactory = tileFactory;
+			EntityFactory = entityFactory;
+		}
+
+		#region Creation Methods
+
+		/// <summary>
+		/// Create an entity on the tile specified, with the type and variation
+		/// </summary>
+		/// <param name="tile">Tile to create the entity on</param>
+		/// <param name="type">Type of the entity</param>
+		/// <param name="variation">Variation of the type</param>
+		/// <param name="properties">Instantiation parameters</param>
+		/// <returns>Reference to the entity created</returns>
+		public IEntity CreateEntity(ITile tile, string type, string variation, params object[] properties)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// Create an area in the level specified, with the type and variation
+		/// </summary>
+		/// <param name="level">Level to add the area to</param>
+		/// <param name="position">Position to add the area in</param>
+		/// <param name="type">Type of the area</param>
+		/// <param name="variation">Variation of the type</param>
+		/// <param name="properties">Instantiation parameters</param>
+		/// <returns>Reference to the area created</returns>
+		public IArea CreateArea(ILevel level, IPosition position, string type, string variation, params object[] properties)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// Create a tile in the area specified, with the type and variatiion
+		/// </summary>
+		/// <param name="area">Area to add the tile to</param>
+		/// <param name="position">Position to add the tile in</param>
+		/// <param name="type">Type of the tile</param>
+		/// <param name="variation">Variation of the type</param>
+		/// <param name="properties">Instantiation parameters</param>
+		/// <returns>Reference to the tile created</returns>
+		public ITile CreateTile(IArea area, IPosition position, string type, string variation, params object[] properties)
+		{
+			throw new NotImplementedException();
+		}
+
+		#endregion
+
+		#region Area Methods
+
+		/// <summary>
+		/// Add area to the current level
+		/// </summary>
+		/// <param name="area">Area you are adding</param>
 		public void Add(IArea area)
 		{
 			throw new NotImplementedException();
 		}
 
+		/// <summary>
+		/// Remove area from the current level
+		/// </summary>
+		/// <param name="area">Area to remove</param>
+		/// <returns>true if an area was removed</returns>
 		public bool Remove(IArea area)
 		{
 			throw new NotImplementedException();
 		}
 
+		/// <summary>
+		/// Get an area at the position defined
+		/// </summary>
+		/// <param name="position">Position to look</param>
+		/// <returns>Reference to the area</returns>
 		public IArea Get(IPosition position)
 		{
 			throw new NotImplementedException();
 		}
 
+		/// <summary>
+		/// Get a list of neighbours for the specified area
+		/// </summary>
+		/// <param name="area">Area to get the neighbours around</param>
+		/// <returns>List of IArea which are next to the supplied area</returns>
 		public List<IArea> GetNeighbours(IArea area)
 		{
 			throw new NotImplementedException();
 		}
+
+		#endregion
 	}
 }

--- a/TileSystem/Implementation/TwoDimension/Level.cs
+++ b/TileSystem/Implementation/TwoDimension/Level.cs
@@ -163,7 +163,7 @@ namespace TileSystem.Implementation.TwoDimension
 
 			IEntity entity = EntityFactory.CreateEntity(type, variation, properties);
 
-			entity.SetParent(tile);
+			entity.SetTile(tile);
 
 			tile.Add(entity);
 
@@ -232,6 +232,7 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Reference to the area</returns>
 		public IArea Get(IPosition position)
 		{
+			// TODO: Issue 15 (https://github.com/Wizcorp/TileSystem/issues/15)
 			throw new NotImplementedException();
 		}
 
@@ -242,6 +243,7 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>List of IArea which are next to the supplied area</returns>
 		public List<IArea> GetNeighbours(IArea area)
 		{
+			// TODO: Issue 15 (https://github.com/Wizcorp/TileSystem/issues/15)
 			throw new NotImplementedException();
 		}
 

--- a/TileSystem/Implementation/TwoDimension/Level.cs
+++ b/TileSystem/Implementation/TwoDimension/Level.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+using TileSystem.Interfaces.Base;
+using TileSystem.Interfaces.Management;
+
+namespace TileSystem.Implementation.TwoDimension
+{
+	public class Level : ILevel
+	{
+		public event EventHandler<AreaAddedArgs> AreaAdded;
+		public event EventHandler<AreaRemovedArgs> AreaRemoved;
+
+		public void Add(IArea area)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool Remove(IArea area)
+		{
+			throw new NotImplementedException();
+		}
+
+		public IArea Get(IPosition position)
+		{
+			throw new NotImplementedException();
+		}
+
+		public List<IArea> GetNeighbours(IArea area)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/TileSystem/Implementation/TwoDimension/Level.cs
+++ b/TileSystem/Implementation/TwoDimension/Level.cs
@@ -54,25 +54,27 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <param name="entityFactory">Entity factory instance</param>
 		public Level(IAreaFactory areaFactory, ITileFactory tileFactory, IEntityFactory entityFactory) : this()
 		{
+			if (areaFactory == null)
+			{
+				throw new ArgumentNullException("areaFactory", "Area Factory can not be null");
+			}
+
+			if (tileFactory == null)
+			{
+				throw new ArgumentNullException("tileFactory", "Tile Factory can not be null");
+			}
+
+			if (entityFactory == null)
+			{
+				throw new ArgumentNullException("entityFactory", "Entity Factory can not be null");
+			}
+
 			AreaFactory = areaFactory;
 			TileFactory = tileFactory;
 			EntityFactory = entityFactory;
 		}
 
 		#region Creation Methods
-
-		/// <summary>
-		/// Create an entity on the tile specified, with the type and variation
-		/// </summary>
-		/// <param name="tile">Tile to create the entity on</param>
-		/// <param name="type">Type of the entity</param>
-		/// <param name="variation">Variation of the type</param>
-		/// <param name="properties">Instantiation parameters</param>
-		/// <returns>Reference to the entity created</returns>
-		public IEntity CreateEntity(ITile tile, string type, string variation, params object[] properties)
-		{
-			throw new NotImplementedException();
-		}
 
 		/// <summary>
 		/// Create an area in the level specified, with the type and variation
@@ -85,7 +87,28 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Reference to the area created</returns>
 		public IArea CreateArea(ILevel level, IPosition position, string type, string variation, params object[] properties)
 		{
-			throw new NotImplementedException();
+			if (level == null)
+			{
+				throw new ArgumentNullException("level", "level can not be null");
+			}
+
+			if (position == null)
+			{
+				throw new ArgumentNullException("position", "position can not be null");
+			}
+
+			IArea area = AreaFactory.CreateArea(type, variation, properties);
+
+			area.SetPosition(level, position);
+
+			level.Add(area);
+
+			if (AreaCreated != null)
+			{
+				AreaCreated.Invoke(this, new AreaCreatedArgs(level, area));
+			}
+
+			return area;
 		}
 
 		/// <summary>
@@ -99,7 +122,57 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Reference to the tile created</returns>
 		public ITile CreateTile(IArea area, IPosition position, string type, string variation, params object[] properties)
 		{
-			throw new NotImplementedException();
+			if (area == null)
+			{
+				throw new ArgumentNullException("area", "area can not be null");
+			}
+
+			if (position == null)
+			{
+				throw new ArgumentNullException("position", "position can not be null");
+			}
+
+			ITile tile = TileFactory.CreateTile(type, variation, properties);
+
+			tile.SetPosition(area, position);
+
+			area.Add(tile);
+
+			if (TileCreated != null)
+			{
+				TileCreated.Invoke(this, new TileCreatedArgs(area, tile));
+			}
+
+			return tile;
+		}
+
+		/// <summary>
+		/// Create an entity on the tile specified, with the type and variation
+		/// </summary>
+		/// <param name="tile">Tile to create the entity on</param>
+		/// <param name="type">Type of the entity</param>
+		/// <param name="variation">Variation of the type</param>
+		/// <param name="properties">Instantiation parameters</param>
+		/// <returns>Reference to the entity created</returns>
+		public IEntity CreateEntity(ITile tile, string type, string variation, params object[] properties)
+		{
+			if (tile == null)
+			{
+				throw new ArgumentNullException("tile", "tile can not be null");
+			}
+
+			IEntity entity = EntityFactory.CreateEntity(type, variation, properties);
+
+			entity.SetParent(tile);
+
+			tile.Add(entity);
+
+			if (EntityCreated != null)
+			{
+				EntityCreated.Invoke(this, new EntityCreatedArgs(tile, entity));
+			}
+
+			return entity;
 		}
 
 		#endregion
@@ -112,7 +185,22 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <param name="area">Area you are adding</param>
 		public void Add(IArea area)
 		{
-			throw new NotImplementedException();
+			if (area == null)
+			{
+				throw new ArgumentNullException("area", "Areas can not be null");
+			}
+
+			if (areas.Contains(area))
+			{
+				throw new ArgumentException("Duplicate value", "area");
+			}
+
+			areas.Add(area);
+
+			if (AreaAdded != null)
+			{
+				AreaAdded.Invoke(this, new AreaAddedArgs(area));
+			}
 		}
 
 		/// <summary>
@@ -122,7 +210,19 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>true if an area was removed</returns>
 		public bool Remove(IArea area)
 		{
-			throw new NotImplementedException();
+			if (area == null)
+			{
+				throw new ArgumentNullException("area", "Areas can not be null");
+			}
+
+			bool removed = areas.Remove(area);
+
+			if (removed && AreaRemoved != null)
+			{
+				AreaRemoved.Invoke(this, new AreaRemovedArgs(area));
+			}
+
+			return removed;
 		}
 
 		/// <summary>

--- a/TileSystem/Implementation/TwoDimension/Tile.cs
+++ b/TileSystem/Implementation/TwoDimension/Tile.cs
@@ -16,6 +16,10 @@ namespace TileSystem.Implementation.TwoDimension
 	/// </summary>
 	public class Tile : ITile
 	{
+		// Position in 2d
+		private IPosition2D position2d;
+
+		// List of entities this tile contains
 		private List<IEntity> entities;
 
 		// Destroyed event from ITile
@@ -31,7 +35,10 @@ namespace TileSystem.Implementation.TwoDimension
 
 		// Location in the system
 		public IArea Area { get; private set; }
-		public IPosition2D Position { get; private set; }
+		public IPosition Position
+		{
+			get { return position2d; }
+		}
 
 		/// <summary>
 		/// Default constructor sets up a list of IEntity
@@ -57,8 +64,8 @@ namespace TileSystem.Implementation.TwoDimension
 		/// Set position in the area of the tile
 		/// </summary>
 		/// <param name="area">Parent area</param>
-		/// <param name="position">position in 2d</param>
-		public void SetPosition(IArea area, IPosition2D position)
+		/// <param name="position">position</param>
+		public void SetPosition(IArea area, IPosition position)
 		{
 			if (area == null)
 			{
@@ -70,8 +77,15 @@ namespace TileSystem.Implementation.TwoDimension
 				throw new ArgumentNullException("position", "Position can not be null");
 			}
 
+			IPosition2D pos = position as IPosition2D;
+
+			if (pos == null)
+			{
+				throw new ArgumentException("position must be of type IPosition2D", "position");
+			}
+
 			Area = area;
-			Position = position;
+			position2d = pos;
 		}
 
 		/// <summary>
@@ -133,6 +147,11 @@ namespace TileSystem.Implementation.TwoDimension
 				}
 			}
 
+			if (Area != null)
+			{
+				Area.Remove(this);
+			}
+
 			if (Destroyed != null)
 			{
 				Destroyed.Invoke(this, new TileDestroyedArgs());
@@ -145,7 +164,7 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Formatted string representation of the Tile(X,Y, Entity Count)</returns>
 		public override string ToString()
 		{
-			return string.Format("[Tile X:{0} Y:{1}, Entities Count:{2}]", Position.X, Position.Y, entities.Count);
+			return string.Format("[Tile X:{0} Y:{1}, Entities Count:{2}]", position2d.X, position2d.Y, entities.Count);
 		}
 	}
 }

--- a/TileSystem/Interfaces/Base/IArea.cs
+++ b/TileSystem/Interfaces/Base/IArea.cs
@@ -30,6 +30,8 @@ namespace TileSystem.Interfaces.Base
 		List<ITile> GetNeighbours(ITile tile);
 
 		ILevel Level { get; }
+		IPosition Position { get; }
+		void SetPosition(ILevel level, IPosition position);
 
 		event EventHandler<AreaDestroyedArgs> Destroyed;
 		void Destroy(bool propagate = false);

--- a/TileSystem/Interfaces/Base/IEntity.cs
+++ b/TileSystem/Interfaces/Base/IEntity.cs
@@ -21,7 +21,7 @@ namespace TileSystem.Interfaces.Base
 		string Variation { get; }
 
 		ITile Tile { get; }
-		void SetParent(ITile tile);
+		void SetTile(ITile tile);
 
 		event EventHandler<EntityDestroyedArgs> Destroyed;
 		void Destroy();

--- a/TileSystem/Interfaces/Base/IEntity.cs
+++ b/TileSystem/Interfaces/Base/IEntity.cs
@@ -10,6 +10,8 @@ namespace TileSystem.Interfaces.Base
 	/// 
 	/// The Tile is a reference to the containing parent for fast traversing
 	/// 
+	/// Set Parent sets the tile that the entity is attached to
+	/// 
 	/// The Destroyed, Destroy and CleanUp are management functions so you can cleanup
 	/// without triggering the event, much like destroy immediate in Unity
 	/// </summary>
@@ -19,6 +21,7 @@ namespace TileSystem.Interfaces.Base
 		string Variation { get; }
 
 		ITile Tile { get; }
+		void SetParent(ITile tile);
 
 		event EventHandler<EntityDestroyedArgs> Destroyed;
 		void Destroy();

--- a/TileSystem/Interfaces/Base/ITile.cs
+++ b/TileSystem/Interfaces/Base/ITile.cs
@@ -24,6 +24,8 @@ namespace TileSystem.Interfaces.Base
 		string Variation { get; }
 
 		IArea Area { get; }
+		IPosition Position { get; }
+		void SetPosition(IArea area, IPosition position);
 
 		event EventHandler<TileDestroyedArgs> Destroyed;
 		void Destroy(bool propagate = false);

--- a/TileSystem/Interfaces/Creation/ICreateAreas.cs
+++ b/TileSystem/Interfaces/Creation/ICreateAreas.cs
@@ -5,14 +5,14 @@ using TileSystem.Interfaces.Base;
 namespace TileSystem.Interfaces.Creation
 {
 	/// <summary>
-	/// ICreateAreas is used by the level to create entities
+	/// ICreateAreas is used to create areas
 	/// using a normal creational pattern
 	/// 
 	/// The level and position will determine where the area is created
 	/// </summary>
 	public interface ICreateAreas
 	{
-		event EventHandler<EntityCreatedArgs> EntityCreated;
+		event EventHandler<AreaCreatedArgs> AreaCreated;
 		IArea CreateArea(ILevel level, IPosition position, string type, string variation, params object[] properties);
 		IAreaFactory AreaFactory { get; }
 	}

--- a/TileSystem/TileSystem.csproj
+++ b/TileSystem/TileSystem.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="Implementation\TwoDimension\Area.cs" />
     <Compile Include="Implementation\TwoDimension\Entity.cs" />
+    <Compile Include="Implementation\TwoDimension\Level.cs" />
     <Compile Include="Implementation\TwoDimension\Position2D.cs" />
     <Compile Include="Implementation\TwoDimension\Tile.cs" />
     <Compile Include="Implementation\Management\TileChangeManager.cs" />


### PR DESCRIPTION
# Description

Implemented the level and the creation of the elements that can go in the level.  To do this I had to add a few properties defined in #10 such as Position and SetPosition.  I am still not 100% sure that Position rather than Position2D is correct here, however to keep the interfaces generic it is required.

The level implementation has ILevel, ICreateAreas, ICreateTiles, ICreateEntities on it, and takes the creation factories in the constructor.  I have left a default constructor so that this can be used as a base class.  I think some of these functions could become virtual in that case, but for the moment I have left them as standard functions.

I did think about having the Add for the Level, Area, and Tile set the parent however I think this could be problematic though in some instances.

I have left the position and GetNeighbours to be implemented and I will add an issue to fix this in another PR
# What Changed
- Added Level
- Updated Area, Tile, Entity, and Interfaces where required
- Implemented Creation of things in Level
- Tests
# New Tests!

![image](https://cloud.githubusercontent.com/assets/3025045/17662075/fc378e02-631d-11e6-8904-757fc2723c4f.png)
