### PR TITLE
Implemented features found in issues #6

### DIFF
--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -171,13 +171,10 @@ namespace Tests.TwoDimension
 		public void PositionGet()
 		{
 			Area area = new Area();
-			var mockLevel = new Mock<ILevel>();
-			var mockPosition = new Mock<IPosition2D>();
 			var mockTile = new Mock<Tile>();
 			var tilePosition = new Position2D(0, 0);
 			var tilePositionNotFound = new Position2D(1, 0);
 
-			area.SetPosition(mockLevel.Object, mockPosition.Object);
 			mockTile.Object.SetPosition(area, tilePosition);
 			area.Add(mockTile.Object);
 
@@ -195,8 +192,6 @@ namespace Tests.TwoDimension
 		public void PositionGetNeighbours()
 		{
 			Area area = new Area();
-			var mockLevel = new Mock<ILevel>();
-			var mockPosition = new Mock<IPosition2D>();
 			var mockTile = new Mock<Tile>();
 			var tilePosition = new Position2D(0, 0);
 			var mockTileNotInArea = new Mock<Tile>();
@@ -207,7 +202,6 @@ namespace Tests.TwoDimension
 			var mockNotANeighbourTile = new Mock<Tile>();
 			var notANeighbourTilePosition = new Position2D(4, 0);
 
-			area.SetPosition(mockLevel.Object, mockPosition.Object);
 			mockTile.Object.SetPosition(area, tilePosition);
 			area.Add(mockTile.Object);
 
@@ -223,15 +217,16 @@ namespace Tests.TwoDimension
 			// Test One Or More Neighbours
 			mockFirstNeighbourTile.Object.SetPosition(area, firstNeighbourTilePosition);
 			area.Add(mockFirstNeighbourTile.Object);
-			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 1);
-
 			mockSecondNeighbourTile.Object.SetPosition(area, secondNeighbourTilePosition);
 			area.Add(mockSecondNeighbourTile.Object);
-			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
-
 			mockNotANeighbourTile.Object.SetPosition(area, notANeighbourTilePosition);
 			area.Add(mockNotANeighbourTile.Object);
-			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
+
+			var neighbourTiles = area.GetNeighbours(mockTile.Object);
+
+			Assert.IsTrue(neighbourTiles.Contains(mockFirstNeighbourTile.Object));
+			Assert.IsTrue(neighbourTiles.Contains(mockSecondNeighbourTile.Object));
+			Assert.IsFalse(neighbourTiles.Contains(mockNotANeighbourTile.Object));
 		}
 	}
 }

--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -194,8 +194,37 @@ namespace Tests.TwoDimension
 		[Test]
 		public void PositionGetNeighbours()
 		{
-			// TODO: Issue 6 (https://github.com/Wizcorp/TileSystem/issues/6)
-			Assert.Fail();
-		}
-	}
+            Area area = new Area();
+            var mockLevel = new Mock<ILevel>();
+            var mockPosition = new Mock<IPosition2D>();
+            var mockTile = new Mock<Tile>();
+            var tilePosition = new Position2D(0, 0);
+            var mockTileNotInArea = new Mock<Tile>();
+            var mockFirstNeighbourTile = new Mock<Tile>();
+            var firstNeighbourTilePosition = new Position2D(1, 0);
+            var mockSecondNeighbourTile = new Mock<Tile>();
+            var secondNeighbourTilePosition = new Position2D(1, 1);
+
+            area.SetPosition(mockLevel.Object, mockPosition.Object);
+            mockTile.Object.SetPosition(area, tilePosition);
+            area.Add(mockTile.Object);
+
+            // Test Nulls
+            Assert.That(() => area.GetNeighbours(null), Throws.ArgumentNullException);
+
+            // Test Tile Not In Area
+            Assert.That(() => area.GetNeighbours(mockTileNotInArea.Object), Throws.ArgumentException);
+
+            // Test No Neighbours
+            Assert.Null(area.GetNeighbours(mockTile.Object));
+
+            // Test One Or More Neighbours
+            mockFirstNeighbourTile.Object.SetPosition(area, firstNeighbourTilePosition);
+            area.Add(mockFirstNeighbourTile.Object);
+            Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 1);
+            mockSecondNeighbourTile.Object.SetPosition(area, secondNeighbourTilePosition);
+            area.Add(mockSecondNeighbourTile.Object);
+            Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
+        }
+    }
 }

--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -170,9 +170,26 @@ namespace Tests.TwoDimension
 		[Test]
 		public void PositionGet()
 		{
-			// TODO: Issue 6 (https://github.com/Wizcorp/TileSystem/issues/6)
-			Assert.Fail();
-		}
+            Area area = new Area();
+            var mockLevel = new Mock<ILevel>();
+            var mockPosition = new Mock<IPosition2D>();
+            var mockTile = new Mock<Tile>();
+            var tilePosition = new Position2D(0, 0);
+            var tilePositionNotFound = new Position2D(1, 0);
+
+            area.SetPosition(mockLevel.Object, mockPosition.Object);
+            mockTile.Object.SetPosition(area, tilePosition);
+            area.Add(mockTile.Object);
+
+            // Test Nulls
+            Assert.That(() => area.Get(null), Throws.ArgumentNullException);
+
+            // Test Same Tile
+            Assert.AreSame(mockTile.Object, area.Get(tilePosition));
+
+            // Test Tile Not Found
+            Assert.AreNotSame(mockTile.Object, area.Get(tilePositionNotFound));
+        }
 
 		[Test]
 		public void PositionGetNeighbours()

--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -204,6 +204,8 @@ namespace Tests.TwoDimension
             var firstNeighbourTilePosition = new Position2D(1, 0);
             var mockSecondNeighbourTile = new Mock<Tile>();
             var secondNeighbourTilePosition = new Position2D(1, 1);
+            var mockNotANeighbourTile = new Mock<Tile>();
+            var notANeighbourTilePosition = new Position2D(4, 0);
 
             area.SetPosition(mockLevel.Object, mockPosition.Object);
             mockTile.Object.SetPosition(area, tilePosition);
@@ -224,6 +226,9 @@ namespace Tests.TwoDimension
             Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 1);
             mockSecondNeighbourTile.Object.SetPosition(area, secondNeighbourTilePosition);
             area.Add(mockSecondNeighbourTile.Object);
+            Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
+            mockNotANeighbourTile.Object.SetPosition(area, notANeighbourTilePosition);
+            area.Add(mockNotANeighbourTile.Object);
             Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
         }
     }

--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -189,7 +189,7 @@ namespace Tests.TwoDimension
 
 			// Test Tile Not Found
 			Assert.AreNotSame(mockTile.Object, area.Get(tilePositionNotFound));
-        }
+		}
 
 		[Test]
 		public void PositionGetNeighbours()
@@ -232,6 +232,6 @@ namespace Tests.TwoDimension
 			mockNotANeighbourTile.Object.SetPosition(area, notANeighbourTilePosition);
 			area.Add(mockNotANeighbourTile.Object);
 			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
-        }
-    }
+		}
+	}
 }

--- a/Tests/TwoDimension/AreaTests.cs
+++ b/Tests/TwoDimension/AreaTests.cs
@@ -170,66 +170,68 @@ namespace Tests.TwoDimension
 		[Test]
 		public void PositionGet()
 		{
-            Area area = new Area();
-            var mockLevel = new Mock<ILevel>();
-            var mockPosition = new Mock<IPosition2D>();
-            var mockTile = new Mock<Tile>();
-            var tilePosition = new Position2D(0, 0);
-            var tilePositionNotFound = new Position2D(1, 0);
+			Area area = new Area();
+			var mockLevel = new Mock<ILevel>();
+			var mockPosition = new Mock<IPosition2D>();
+			var mockTile = new Mock<Tile>();
+			var tilePosition = new Position2D(0, 0);
+			var tilePositionNotFound = new Position2D(1, 0);
 
-            area.SetPosition(mockLevel.Object, mockPosition.Object);
-            mockTile.Object.SetPosition(area, tilePosition);
-            area.Add(mockTile.Object);
+			area.SetPosition(mockLevel.Object, mockPosition.Object);
+			mockTile.Object.SetPosition(area, tilePosition);
+			area.Add(mockTile.Object);
 
-            // Test Nulls
-            Assert.That(() => area.Get(null), Throws.ArgumentNullException);
+			// Test Nulls
+			Assert.That(() => area.Get(null), Throws.ArgumentNullException);
 
-            // Test Same Tile
-            Assert.AreSame(mockTile.Object, area.Get(tilePosition));
+			// Test Same Tile
+			Assert.AreSame(mockTile.Object, area.Get(tilePosition));
 
-            // Test Tile Not Found
-            Assert.AreNotSame(mockTile.Object, area.Get(tilePositionNotFound));
+			// Test Tile Not Found
+			Assert.AreNotSame(mockTile.Object, area.Get(tilePositionNotFound));
         }
 
 		[Test]
 		public void PositionGetNeighbours()
 		{
-            Area area = new Area();
-            var mockLevel = new Mock<ILevel>();
-            var mockPosition = new Mock<IPosition2D>();
-            var mockTile = new Mock<Tile>();
-            var tilePosition = new Position2D(0, 0);
-            var mockTileNotInArea = new Mock<Tile>();
-            var mockFirstNeighbourTile = new Mock<Tile>();
-            var firstNeighbourTilePosition = new Position2D(1, 0);
-            var mockSecondNeighbourTile = new Mock<Tile>();
-            var secondNeighbourTilePosition = new Position2D(1, 1);
-            var mockNotANeighbourTile = new Mock<Tile>();
-            var notANeighbourTilePosition = new Position2D(4, 0);
+			Area area = new Area();
+			var mockLevel = new Mock<ILevel>();
+			var mockPosition = new Mock<IPosition2D>();
+			var mockTile = new Mock<Tile>();
+			var tilePosition = new Position2D(0, 0);
+			var mockTileNotInArea = new Mock<Tile>();
+			var mockFirstNeighbourTile = new Mock<Tile>();
+			var firstNeighbourTilePosition = new Position2D(1, 0);
+			var mockSecondNeighbourTile = new Mock<Tile>();
+			var secondNeighbourTilePosition = new Position2D(1, 1);
+			var mockNotANeighbourTile = new Mock<Tile>();
+			var notANeighbourTilePosition = new Position2D(4, 0);
 
-            area.SetPosition(mockLevel.Object, mockPosition.Object);
-            mockTile.Object.SetPosition(area, tilePosition);
-            area.Add(mockTile.Object);
+			area.SetPosition(mockLevel.Object, mockPosition.Object);
+			mockTile.Object.SetPosition(area, tilePosition);
+			area.Add(mockTile.Object);
 
-            // Test Nulls
-            Assert.That(() => area.GetNeighbours(null), Throws.ArgumentNullException);
+			// Test Nulls
+			Assert.That(() => area.GetNeighbours(null), Throws.ArgumentNullException);
 
-            // Test Tile Not In Area
-            Assert.That(() => area.GetNeighbours(mockTileNotInArea.Object), Throws.ArgumentException);
+			// Test Tile Not In Area
+			Assert.That(() => area.GetNeighbours(mockTileNotInArea.Object), Throws.ArgumentException);
 
-            // Test No Neighbours
-            Assert.Null(area.GetNeighbours(mockTile.Object));
+			// Test No Neighbours
+			Assert.Null(area.GetNeighbours(mockTile.Object));
 
-            // Test One Or More Neighbours
-            mockFirstNeighbourTile.Object.SetPosition(area, firstNeighbourTilePosition);
-            area.Add(mockFirstNeighbourTile.Object);
-            Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 1);
-            mockSecondNeighbourTile.Object.SetPosition(area, secondNeighbourTilePosition);
-            area.Add(mockSecondNeighbourTile.Object);
-            Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
-            mockNotANeighbourTile.Object.SetPosition(area, notANeighbourTilePosition);
-            area.Add(mockNotANeighbourTile.Object);
-            Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
+			// Test One Or More Neighbours
+			mockFirstNeighbourTile.Object.SetPosition(area, firstNeighbourTilePosition);
+			area.Add(mockFirstNeighbourTile.Object);
+			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 1);
+
+			mockSecondNeighbourTile.Object.SetPosition(area, secondNeighbourTilePosition);
+			area.Add(mockSecondNeighbourTile.Object);
+			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
+
+			mockNotANeighbourTile.Object.SetPosition(area, notANeighbourTilePosition);
+			area.Add(mockNotANeighbourTile.Object);
+			Assert.IsTrue(area.GetNeighbours(mockTile.Object).Count == 2);
         }
     }
 }

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -141,12 +141,12 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Tile instance or null</returns>
 		public ITile Get(IPosition position)
 		{
-            if (position == null)
-            {
-                throw new ArgumentNullException("position", "Position can not be null");
-            }
+			if (position == null)
+			{
+			    throw new ArgumentNullException("position", "Position can not be null");
+			}
 
-            return tiles.Find(tile => tile.Position.CompareTo(position) == 0);
+			return tiles.Find(tile => tile.Position.CompareTo(position) == 0);
 		}
 
 		/// <summary>
@@ -156,28 +156,28 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>List of neighbours or null</returns>
 		public List<ITile> GetNeighbours(ITile tile)
 		{
-            if (tile == null)
-            {
-                throw new ArgumentNullException("tile", "Tile can not be null");
-            }
+			if (tile == null)
+			{
+			    throw new ArgumentNullException("tile", "Tile can not be null");
+			}
 
-            if (tiles.Contains(tile) == false)
-            {
-                throw new ArgumentException("Tile not in Area", "tile");
-            }
+			if (tiles.Contains(tile) == false)
+			{
+			    throw new ArgumentException("Tile not in Area", "tile");
+			}
 
-            List<ITile> neigbourTiles = tiles.FindAll(t => 
-                Math.Abs(((Position2D)t.Position).X - ((Position2D)tile.Position).X) == 1 ||
-                Math.Abs(((Position2D)t.Position).Y - ((Position2D)tile.Position).Y) == 1);
+			List<ITile> neigbourTiles = tiles.FindAll(t => 
+			    Math.Abs(((Position2D)t.Position).X - ((Position2D)tile.Position).X) == 1 ||
+			    Math.Abs(((Position2D)t.Position).Y - ((Position2D)tile.Position).Y) == 1);
 
-            if (neigbourTiles.Count <= 0)
-            {
-                return null;
-            }
-            else
-            {
-                return neigbourTiles;
-            }
+			if (neigbourTiles.Count <= 0)
+			{
+			    return null;
+			}
+			else
+			{
+			    return neigbourTiles;
+			}
         }
 
 		/// <summary>

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -141,8 +141,12 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>Tile instance or null</returns>
 		public ITile Get(IPosition position)
 		{
-			// TODO: Issue 6 (https://github.com/Wizcorp/TileSystem/issues/6)
-			throw new NotImplementedException();
+            if (position == null)
+            {
+                throw new ArgumentNullException("position", "Position can not be null");
+            }
+
+            return tiles.Find(tile => tile.Position.CompareTo(position) == 0);
 		}
 
 		/// <summary>

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -178,7 +178,7 @@ namespace TileSystem.Implementation.TwoDimension
 			{
 			    return neigbourTiles;
 			}
-        }
+		}
 
 		/// <summary>
 		/// Destroy this area and emit the event

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -156,9 +156,29 @@ namespace TileSystem.Implementation.TwoDimension
 		/// <returns>List of neighbours or null</returns>
 		public List<ITile> GetNeighbours(ITile tile)
 		{
-			// TODO: Issue 6 (https://github.com/Wizcorp/TileSystem/issues/6)
-			throw new NotImplementedException();
-		}
+            if (tile == null)
+            {
+                throw new ArgumentNullException("tile", "Tile can not be null");
+            }
+
+            if (tiles.Contains(tile) == false)
+            {
+                throw new ArgumentException("Tile not in Area", "tile");
+            }
+
+            List<ITile> neigbourTiles = tiles.FindAll(t => 
+                Math.Abs(((Position2D)t.Position).X - ((Position2D)tile.Position).X) == 1 ||
+                Math.Abs(((Position2D)t.Position).Y - ((Position2D)tile.Position).Y) == 1);
+
+            if (neigbourTiles.Count <= 0)
+            {
+                return null;
+            }
+            else
+            {
+                return neigbourTiles;
+            }
+        }
 
 		/// <summary>
 		/// Destroy this area and emit the event

--- a/TileSystem/Implementation/TwoDimension/Area.cs
+++ b/TileSystem/Implementation/TwoDimension/Area.cs
@@ -143,7 +143,7 @@ namespace TileSystem.Implementation.TwoDimension
 		{
 			if (position == null)
 			{
-			    throw new ArgumentNullException("position", "Position can not be null");
+				throw new ArgumentNullException("position", "Position can not be null");
 			}
 
 			return tiles.Find(tile => tile.Position.CompareTo(position) == 0);
@@ -158,25 +158,25 @@ namespace TileSystem.Implementation.TwoDimension
 		{
 			if (tile == null)
 			{
-			    throw new ArgumentNullException("tile", "Tile can not be null");
+				throw new ArgumentNullException("tile", "Tile can not be null");
 			}
 
 			if (tiles.Contains(tile) == false)
 			{
-			    throw new ArgumentException("Tile not in Area", "tile");
+				throw new ArgumentException("Tile not in Area", "tile");
 			}
 
 			List<ITile> neigbourTiles = tiles.FindAll(t => 
-			    Math.Abs(((Position2D)t.Position).X - ((Position2D)tile.Position).X) == 1 ||
-			    Math.Abs(((Position2D)t.Position).Y - ((Position2D)tile.Position).Y) == 1);
+				Math.Abs(((Position2D)t.Position).X - ((Position2D)tile.Position).X) == 1 ||
+				Math.Abs(((Position2D)t.Position).Y - ((Position2D)tile.Position).Y) == 1);
 
 			if (neigbourTiles.Count <= 0)
 			{
-			    return null;
+				return null;
 			}
 			else
 			{
-			    return neigbourTiles;
+				return neigbourTiles;
 			}
 		}
 


### PR DESCRIPTION
I've added both the Get and GetNeighbours methods from the class Area, with the unit tests.
The GetNeighbours method actually returns up to 8 neighbours (top-left, top, top-right, left, right, bottom-left, bottom, bottom-right)
I've assumed that since the Area position uses IPosition2D, the same goes for the Tiles added to that area.